### PR TITLE
add: regex to check valid key for k8s and multiline envs

### DIFF
--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -178,7 +178,7 @@ func ParseSecretEnvironmentVariables(data string) (map[string]string, error) {
 
 // multiline: true
 func ParsMultiLineEnvironmentVariables(data string) (map[string]string, error) {
-	lines := strings.Split(data, "&")
+	lines := strings.Split(data, "\\")
 	return ParseSecrets(lines)
 }
 

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -174,7 +174,7 @@ func TestSynchronizer_Sync_DeleteNotFoundSecret(t *testing.T) {
 }
 
 func TestParseSecretEnvironmentVariables(t *testing.T) {
-	validMetadata := "KEY.VALUE=VALUE\nKEY-VALUE=VALUE\nKEY_VALUE=VALUE\nKEY0VALUE=VALUE"
+	validMetadata := "KEY.VALUE=VALUE\nKEY-VALUE=VALUE\nKEY_VALUE=VALUE\nKEY0VALUE=VALUE\nkey_VALUE.s=VALUE"
 	result, _ := synchronizer.ParseSecretEnvironmentVariables(validMetadata)
 
 	lines := strings.Split(validMetadata, "\n")
@@ -192,4 +192,10 @@ func TestParseSecretEnvironmentVariables(t *testing.T) {
 	expectedErrorMsg := "pattern: '^[a-zA-Z0-9-_.]+$' do not match for environment key: KEY$VALUE"
 	assert.EqualErrorf(t, err, expectedErrorMsg, "Error should be: %v, got: %v", expectedErrorMsg, err)
 	assert.True(t, len(result) == 0)
+}
+
+func TestParsMultiLineEnvironmentVariables(t *testing.T) {
+	validMetadata := "FIRST_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIEsomekey\n-----END RSA PRIVATE KEY-----\n && OTHER_KEY=VALUE"
+	result, _ := synchronizer.ParsMultiLineEnvironmentVariables(validMetadata)
+	assert.True(t, len(result) == 2)
 }

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -198,4 +198,6 @@ func TestParsMultiLineEnvironmentVariables(t *testing.T) {
 	validMetadata := "FIRST_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIEsomekey\n-----END RSA PRIVATE KEY-----\n && OTHER_KEY=VALUE"
 	result, _ := synchronizer.ParsMultiLineEnvironmentVariables(validMetadata)
 	assert.True(t, len(result) == 2)
+	assert.True(t, result["FIRST_KEY"] == "-----BEGIN RSA PRIVATE KEY-----\nMIIEsomekey\n-----END RSA PRIVATE KEY-----")
+	assert.True(t, result["OTHER_KEY"] == "VALUE")
 }


### PR DESCRIPTION
In the documentation from kubernetes you can read: https://v1-18.docs.kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually `The keys of data and stringData must consist of alphanumeric characters, '-', '_' or '.'.` 

I think it could be a good to force this so that developers dont add stuff to their secret config not compatible with k8s.

But im not sure the regex is correct according to the k8s spec for accepted values

edit:

~Added ability for multiline envs. delimiter `&&` can be replaced with something more elegant/right?~

edit 2:

A better approach is to use `\` backslash for separate env. vars?